### PR TITLE
Adding import for os module so builds don't break

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
+import os
 
 # REPLACE THESE VARIABLES
 # this should be the name of your source directory like "imagepypelines_template"


### PR DESCRIPTION
I'll need to change this in the template too then I suppose.

For context, not importing os module breaks setup.py installation which breaks the imagepypelines build